### PR TITLE
remove unnecessary dependency on argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 pbr>=1.6
-argparse
 cmd2>=0.6.7
 PrettyTable<0.8,>=0.7
 pyparsing>=2.0.1


### PR DESCRIPTION
argparse is not required for Python 2.7 and 3.2+ (which are the only
Python versions explicitely supported in setup.py)

removing the unnecessary argparse dependency to allow package to be
properly packaged on Debian/Ubuntu systems.