### PR TITLE
Use OS_PROMPT, if set, for the command line prompt

### DIFF
--- a/cliff/interactive.py
+++ b/cliff/interactive.py
@@ -6,7 +6,7 @@ import shlex
 import sys
 
 import cmd2
-
+import os
 
 class InteractiveApp(cmd2.Cmd):
     """Provides "interactive mode" features.
@@ -32,7 +32,7 @@ class InteractiveApp(cmd2.Cmd):
     def __init__(self, parent_app, command_manager, stdin, stdout):
         self.parent_app = parent_app
         if not hasattr(sys.stdin, 'isatty') or sys.stdin.isatty():
-            self.prompt = '(%s) ' % parent_app.NAME
+            self.prompt = '(%s) ' % (os.environ.get('OS_PROMPT') or parent_app.NAME)
         else:
             # batch/pipe mode
             self.prompt = ''


### PR DESCRIPTION
I find this useful in our OpenStack environment where users might be charging resources against multiple projects. In those cases, I can have OS_PROJECT_NAME as part of the OS_PROMPT to make it clear which one the resources count against.