### PR TITLE
List setuptools under install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['pbr>=2.0.0'],
+    install_requires=['setuptools'],
     pbr=True)


### PR DESCRIPTION
Hi,
`pkg_resources` is used, making setuptools a runtime dependency.